### PR TITLE
A better setting?

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -24,7 +24,7 @@ closeConnectionAfterSeconds: 10
 # in mhz
 # Valid values are '16' and '8', but 8 seems to be
 # too low to get accurate transcriptions
-sampleRate: '16'
+sampleRate: '32'
 
 # Each transcription server has its own config section
 # startMessage and endMessage are the messages sent whenever mod_audio_fork's
@@ -47,7 +47,7 @@ vosk:
 # the start/end messages right
 
 gladia:
-  startMessage: '{"x_gladia_key": "", "sample_rate": 32000, "bit_depth": 24, "model_type": "accurate", "endpointing": 300 }'
+  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 24, "model_type": "accurate", "endpointing": 300 }'
   endMessage: '{}'
   server: ws://localhost:8777
   proxy:

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -47,8 +47,7 @@ vosk:
 # the start/end messages right
 
 gladia:
-  #startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "accurate", "endpointing": 300, "audio_enhancer": true }'
-  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "accurate", "endpointing": 10 }'
+  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "accurate", "endpointing": 300, "audio_enhancer": true }'
   endMessage: '{}'
   server: ws://localhost:8777
   proxy:

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -24,7 +24,7 @@ closeConnectionAfterSeconds: 10
 # in mhz
 # Valid values are '16' and '8', but 8 seems to be
 # too low to get accurate transcriptions
-sampleRate: '32'
+sampleRate: '16'
 
 # Each transcription server has its own config section
 # startMessage and endMessage are the messages sent whenever mod_audio_fork's

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -47,7 +47,8 @@ vosk:
 # the start/end messages right
 
 gladia:
-  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "accurate", "endpointing": 300, "audio_enhancer": true }'
+  #startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "accurate", "endpointing": 300, "audio_enhancer": true }'
+  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "accurate", "endpointing": 10 }'
   endMessage: '{}'
   server: ws://localhost:8777
   proxy:

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -47,7 +47,7 @@ vosk:
 # the start/end messages right
 
 gladia:
-  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "accurate", "endpointing": 300 }'
+  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "accurate", "endpointing": 300, "audio_enhancer": true }'
   endMessage: '{}'
   server: ws://localhost:8777
   proxy:

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -47,7 +47,7 @@ vosk:
 # the start/end messages right
 
 gladia:
-  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 24, "model_type": "accurate", "endpointing": 300 }'
+  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "accurate", "endpointing": 300 }'
   endMessage: '{}'
   server: ws://localhost:8777
   proxy:

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -47,7 +47,7 @@ vosk:
 # the start/end messages right
 
 gladia:
-  startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "fast", "endpointing": 300 }'
+  startMessage: '{"x_gladia_key": "", "sample_rate": 32000, "bit_depth": 24, "model_type": "accurate", "endpointing": 300 }'
   endMessage: '{}'
   server: ws://localhost:8777
   proxy:


### PR DESCRIPTION
/usr/local/bigbluebutton/bbb-transcription-controller/config/default.yml

Sample rate of 32000 Hz is not accepted, API does not start.
Bit rate of 24 bit does not improve, or break the transcription, probably BBB uses 16 bit audio.